### PR TITLE
OS X support

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -95,7 +95,8 @@ maybe_install_make() {
         info "Downloading Make 4.0 to $QAKE_INSTALL_DIR/$MAKE_FILENAME"
         wget http://ftp.gnu.org/gnu/make/$MAKE_FILENAME \
             -O $QAKE_INSTALL_DIR/$MAKE_FILENAME
-        tar -C $QAKE_INSTALL_DIR -xaf $MAKE_FILENAME
+        cd $QAKE_INSTALLDIR
+        tar -xf $QAKE_INSTALL_DIR/$MAKE_FILENAME
         cd make-4.0
         info "Configuring Make 4.0"
         try ./configure --prefix="$QAKE_MAKE_INSTALL_DIR" > /dev/null
@@ -103,8 +104,7 @@ maybe_install_make() {
         try make -j > /dev/null
         info "Installing Make 4.0 to $QAKE_MAKE_INSTALL_DIR"
         try make install -j > /dev/null
-        cd - > /dev/null
-        echo "$MAKE" > .make_path
+        echo "$MAKE" > $QAKE_INSTALL_DIR/.make_path
     fi
 }
 

--- a/prologue.mk
+++ b/prologue.mk
@@ -1,3 +1,11 @@
+ifeq (, $(shell which md5sum))
+  # BSD derived systems (OS X, FreeBSD, etc.) use md5 instead of md5sum that 
+  # is available on Linux
+  HASH := md5
+else
+  HASH := md5sum
+endif
+  
 # This is to precisely track what's going on.
 # It's used by Make as command interpreter.
 # By default, Make uses /bin/sh as interpreter for recipes.
@@ -437,17 +445,17 @@ $(AUX_DIR)/%.hash.new
 $(AUX_DIR)/%.hash.new: \
   $(RES_DIR)/% \
 | $$(DIRECTORY)
-> md5sum $$< > $$@
+> $(HASH) $$< > $$@
 
 $(AUX_DIR)/%.hash.new: \
   $(SRC_DIR)/% \
 | $$(DIRECTORY)
-> md5sum $$< > $$@
+> $(HASH) $$< > $$@
 
 $(AUX_DIR)/%.hash.new: \
   $(AUX_DIR)/% \
 | $$(DIRECTORY)
-> md5sum $$< > $$@
+> $(HASH) $$< > $$@
 
 $(call TRACE1,DEP_$(call &,$0,BUILT_NAME) := $(strip \
   $$(patsubst $(call NORM_PATH,$(RES_DIR)/$(BUILT_NAME))/%,$(call NORM_PATH,$(AUX_DIR)/$(BUILT_NAME))/%.d,$$(OBJ_$(call &,$0,BUILT_NAME)))))

--- a/qake
+++ b/qake
@@ -21,9 +21,9 @@ parse_arguments() {
 
 parse_arguments "$@"
 
-if [ -f .make_path ]
+if [ -f $QAKE_INCLUDE_DIR/.make_path ]
 then
-    readonly MAKE=$(cat .make_path)
+    readonly MAKE=$(cat $QAKE_INCLUDE_DIR/.make_path)
 else
     readonly MAKE='/usr/bin/env make'
 fi


### PR DESCRIPTION
Suggested changes to support OS X.

Note that these suggestions cannot be applied as is since:
- prologue.mk was modified to use OS X 'md5' rather than Linux' 'md5sum'. This should be automatically configured.
- qake script changed to use locally installed gmake 4.0. This should depend on whether we chose to install it. Otherwise, continue using the system default.
